### PR TITLE
use Long instead of Int for scan cursor

### DIFF
--- a/src/main/scala/redis/RedisCommand.scala
+++ b/src/main/scala/redis/RedisCommand.scala
@@ -80,16 +80,16 @@ trait RedisCommandMultiBulkSeqByteStringDouble[R] extends RedisCommandMultiBulk[
   def decodeReply(mb: MultiBulk) = MultiBulkConverter.toSeqTuple2ByteStringDouble(mb)(deserializer)
 }
 
-case class Cursor[T](index: Int, data: T)
+case class Cursor[T](index: Long, data: T)
 
 trait RedisCommandMultiBulkCursor[R] extends RedisCommandMultiBulk[Cursor[R]] {
   def decodeReply(mb: MultiBulk) = {
     mb.responses.map { responses =>
-      val cursor = ParseNumber.parseInt(responses.head.toByteString)
+      val cursor = ParseNumber.parseLong(responses.head.toByteString)
       val remainder = responses(1).asInstanceOf[MultiBulk]
 
       Cursor(cursor, remainder.responses.map(decodeResponses).getOrElse(empty))
-    }.getOrElse(Cursor(0, empty))
+    }.getOrElse(Cursor(0L, empty))
   }
 
   def decodeResponses(responses: Seq[RedisReply]): R

--- a/src/main/scala/redis/commands/Keys.scala
+++ b/src/main/scala/redis/commands/Keys.scala
@@ -98,7 +98,7 @@ trait Keys extends Request {
   def `type`(key: String): Future[String] =
     send(Type(key))
 
-  def scan(cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Seq[String]]] =
+  def scan(cursor: Long = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Seq[String]]] =
     send(Scan(cursor, count, matchGlob))
 
   def unlink(keys: String*): Future[Long] =


### PR DESCRIPTION
Using `Int` to store cursors return by redis command `Scan` could be overflow in newer version of Redis server, so we should use `Long` instead. 